### PR TITLE
spr: add spr_obsolete index

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ CREATE INDEX spr_by_deprecated ON spr (is_deprecated, lastmodified);
 CREATE INDEX spr_by_ceased ON spr (is_ceased, lastmodified);
 CREATE INDEX spr_by_superseded ON spr (is_superseded, lastmodified);
 CREATE INDEX spr_by_superseding ON spr (is_superseding, lastmodified);
+CREATE INDEX spr_obsolete ON spr (is_deprecated, is_superseded);
 ```
 
 ## Custom tables

--- a/tables/spr.go
+++ b/tables/spr.go
@@ -75,7 +75,7 @@ func (t *SPRTable) Name() string {
 
 func (t *SPRTable) Schema() string {
 
-	sql := `CREATE TABLE %s (
+	sql := `CREATE TABLE %[1]s (
 			id INTEGER NOT NULL PRIMARY KEY,
 			parent_id INTEGER,
 			name TEXT,
@@ -98,23 +98,23 @@ func (t *SPRTable) Schema() string {
 			lastmodified INTEGER
 	);
 
-	CREATE INDEX spr_by_lastmod ON %s (lastmodified);
-	CREATE INDEX spr_by_parent ON %s (parent_id, is_current, lastmodified);
-	CREATE INDEX spr_by_placetype ON %s (placetype, is_current, lastmodified);
-	CREATE INDEX spr_by_country ON %s (country, placetype, is_current, lastmodified);
-	CREATE INDEX spr_by_name ON %s (name, placetype, is_current, lastmodified);
-	CREATE INDEX spr_by_centroid ON %s (latitude, longitude, is_current, lastmodified);
-	CREATE INDEX spr_by_bbox ON %s (min_latitude, min_longitude, max_latitude, max_longitude, placetype, is_current, lastmodified);
-	CREATE INDEX spr_by_repo ON %s (repo, lastmodified);
-	CREATE INDEX spr_by_current ON %s (is_current, lastmodified);
-	CREATE INDEX spr_by_deprecated ON %s (is_deprecated, lastmodified);
-	CREATE INDEX spr_by_ceased ON %s (is_ceased, lastmodified);
-	CREATE INDEX spr_by_superseded ON %s (is_superseded, lastmodified);
-	CREATE INDEX spr_by_superseding ON %s (is_superseding, lastmodified);
+	CREATE INDEX spr_by_lastmod ON %[1]s (lastmodified);
+	CREATE INDEX spr_by_parent ON %[1]s (parent_id, is_current, lastmodified);
+	CREATE INDEX spr_by_placetype ON %[1]s (placetype, is_current, lastmodified);
+	CREATE INDEX spr_by_country ON %[1]s (country, placetype, is_current, lastmodified);
+	CREATE INDEX spr_by_name ON %[1]s (name, placetype, is_current, lastmodified);
+	CREATE INDEX spr_by_centroid ON %[1]s (latitude, longitude, is_current, lastmodified);
+	CREATE INDEX spr_by_bbox ON %[1]s (min_latitude, min_longitude, max_latitude, max_longitude, placetype, is_current, lastmodified);
+	CREATE INDEX spr_by_repo ON %[1]s (repo, lastmodified);
+	CREATE INDEX spr_by_current ON %[1]s (is_current, lastmodified);
+	CREATE INDEX spr_by_deprecated ON %[1]s (is_deprecated, lastmodified);
+	CREATE INDEX spr_by_ceased ON %[1]s (is_ceased, lastmodified);
+	CREATE INDEX spr_by_superseded ON %[1]s (is_superseded, lastmodified);
+	CREATE INDEX spr_by_superseding ON %[1]s (is_superseding, lastmodified);
+	CREATE INDEX spr_obsolete ON %[1]s (is_deprecated, is_superseded);
 	`
 
-	// so dumb...
-	return fmt.Sprintf(sql, t.Name(), t.Name(), t.Name(), t.Name(), t.Name(), t.Name(), t.Name(), t.Name(), t.Name(), t.Name(), t.Name(), t.Name(), t.Name(), t.Name())
+	return fmt.Sprintf(sql, t.Name())
 }
 
 func (t *SPRTable) IndexRecord(db sqlite.Database, i interface{}) error {


### PR DESCRIPTION
This PR adds a new index to the `spr` tabled named `spr_obsolete`.

We often use queries with clauses such as this to filter out `deprecated` and `superseded` records:

```sql
FROM spr
WHERE spr.is_deprecated = 0
AND spr.is_superseded = 0;
```

Without this index, these queries take significantly longer to execute, as shown in this testcase:

```sql
.timer off
SELECT '--- Drop index ---';
DROP INDEX IF EXISTS spr_obsolete;

SELECT '--- Query without index ---';
.timer on
SELECT COUNT(*)
FROM spr
WHERE spr.is_deprecated = 0
AND spr.is_superseded = 0;

.timer off
SELECT '--- Create index ---';
CREATE INDEX IF NOT EXISTS spr_obsolete ON spr (is_deprecated, is_superseded);

SELECT '--- Query with index ---';
.timer on
SELECT COUNT(*)
FROM spr
WHERE spr.is_deprecated = 0
AND spr.is_superseded = 0;
```

```bash
sqlite3 whosonfirst-data-latest.db < query.sql
--- Drop index ---
--- Query without index ---
4822600
Run Time: real 7.666 user 5.224467 sys 2.427607
--- Create index ---
--- Query with index ---
4822600
Run Time: real 0.167 user 0.151846 sys 0.015144
```

The index greatly improves execution times of any queries which target these two fields.
I'd like to have this merged in to master so that we don't have to patch canonical distribution files.

note: I'm not wed to the name `spr_obsolete`, happy to change it to something else if you like?